### PR TITLE
Format empty tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Convert MS SQL Schema to PlantUML diagram source using Python
  |-u, --user *user name*|User name to log in as.<br>Omit to use trusted authentication with SQL Server|
  |-P, --password *password*|Password to log in with<br>omit to use trusted authentication with SQL Server|
  |-D, --driver *ODBC Driver name*|ODBC Driver name to override in connection string<br>Use `Get-OdbcDriver` in PowerShell to get full list of drivers on your system|
+ |-z, --zerorows *mode*|mode=<br>`show` to display empty tables as "greyed-out",<br>`hide` to omit empty tables, retaining space,<br>`remove` to omit empty tables and reclaim space|
 
 **Example:** 
 


### PR DESCRIPTION
In using `sql2pml` for "de novo" reverse engineering of a large database--particularly a vendor database, it can be helpful, off the top, to know which tables are empty.  For example, many vendor databases contain tables for configuration of user interface modules which are not licensed.  These tables can often, or at least initially be safely ignored.

I've added support for a `-z, --zerorows` option with `show`, `hide`, and `remove` values to change the formatting of empty tables, and included updates to the usage and README docs.

The changes were tested successfully with SqlServer, and the MySQL query was tested as well. I could not successfully configure the MySQL odbc driver though--so that row count query is technically untested in situ, but the sql is sound.

The "merge" commits included in the PR are insignificant, but by all means confirm.

normal (omit `-z` option):
<img width="470" alt="image" src="https://user-images.githubusercontent.com/4147512/172464959-a17c0f69-b67a-4096-a9f9-a61cf0705937.png">

`-z show`:
<img width="476" alt="image" src="https://user-images.githubusercontent.com/4147512/172465474-24e58149-ec20-4234-a581-af29b46617c0.png">

`-z hide`:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/4147512/172464000-9c41930a-01ca-4354-980c-45ad58b15ca6.png">

`-z remove`:

<img width="470" alt="image" src="https://user-images.githubusercontent.com/4147512/172465281-96fbf3ff-ebed-411c-af32-9ea356f63338.png">

